### PR TITLE
Use run name from csv file and save to metadata

### DIFF
--- a/Linux/runShiny.R
+++ b/Linux/runShiny.R
@@ -11,6 +11,14 @@ args=commandArgs(asValues=TRUE)
 Data<-args$Rdata
 cnvs <- args$cnvs
 
+# Save metadata file
+run_name <- gsub("_cnvs.csv$", "", basename(cnvs))
+write.csv(
+  data.frame(attrib = c("run_name"), value = c(run_name)),
+  "shinyGUI/metadata.csv",
+  row.names=FALSE
+  )
+
 file.copy(Data, "shinyGUI/Data.RData",overwrite=TRUE)
 file.copy(cnvs, "shinyGUI/cnvs.csv",overwrite=TRUE)
 runApp("shinyGUI",launch.browser=F, host='0.0.0.0', port=5888)

--- a/Linux/shinyGUI/metadata.R
+++ b/Linux/shinyGUI/metadata.R
@@ -1,0 +1,6 @@
+### Any extra metadata to be shared with the front end and back end can be defined here
+
+# extract metadata from csv
+metadata <- read.csv('metadata.csv')
+run_name <- metadata[metadata['attrib'] == 'run_name', 'value']
+print("metadata.R: loaded run_name")

--- a/Linux/shinyGUI/ui.R
+++ b/Linux/shinyGUI/ui.R
@@ -3,9 +3,9 @@ packrat::on()
 library(shiny)
 library(ggplot2)
 
+source('metadata.R')
 
-
-shinyUI(navbarPage("DECoN",
+shinyUI(navbarPage(run_name,
 
 
 	tabPanel("Introduction",


### PR DESCRIPTION
Parsing the name is a bit ugly but easiest way that doesn't change the goshg2p.

Kept it so that we can expand the metadata if we want (if we do this then maybe write the metadata file from django and pass it in as an argument) 